### PR TITLE
Add playlist tab with MongoDB storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ TELEGRAM_BOT_TOKEN=your-bot-token
 TELEGRAM_CHAT_ID=your-chat-id
 ```
 
-3. Ensure your MongoDB service is running.
+3. Ensure your MongoDB service is running. The application and maintenance scripts use a database named `hope-app`.
 
 4. Start the application:
 

--- a/cleanup-db.js
+++ b/cleanup-db.js
@@ -7,7 +7,7 @@ async function cleanup() {
         await client.connect();
         console.log('Connected to MongoDB');
         
-        const db = client.db('hope');
+        const db = client.db('hope-app');
         const media = db.collection('media');
         
         // Remove localPath field from all entries

--- a/database.js
+++ b/database.js
@@ -13,6 +13,7 @@ async function connectToDb() {
         db = client.db('hope-app');
         // Create indexes for searching
         await db.collection('media').createIndex({ title: 'text', hashtags: 'text' });
+        await db.collection('playlists').createIndex({ name: 1 });
         return db;
     } catch (err) {
         console.error('Failed to connect to MongoDB', err);

--- a/index.html
+++ b/index.html
@@ -99,6 +99,7 @@
         <div class="tab" onclick="switchTab('home')">Home</div>
         <div class="tab" onclick="switchTab('theater')">Theater</div>
         <div class="tab active" onclick="switchTab('media')">Media Player</div>
+        <div class="tab" onclick="switchTab('playlists')">Playlist</div>
         <div class="tab" onclick="switchTab('debug')">Debug</div>
     </div>
 
@@ -135,6 +136,15 @@
         </div>
     </div>
 
+    <div id="playlists" class="tab-content">
+        <h2>Playlists</h2>
+        <div style="display:flex; gap:5px; margin-bottom:10px;">
+            <input type="text" id="new-playlist-name" placeholder="New playlist name">
+            <button id="create-playlist-btn">Create</button>
+        </div>
+        <div id="playlist-list"></div>
+    </div>
+
     <div id="debug" class="tab-content">
         <h2>Debug Logs</h2>
         <pre id="log-area" style="overflow-y: auto; height: 100%; background: #f8f8f8; padding: 10px; border: 1px solid #ddd;"></pre>
@@ -144,6 +154,7 @@
         // Global state
         let logs = [];
         let allMediaData = null;
+        let playlistsData = [];
 
         // Tab switching
         function switchTab(tabId) {
@@ -154,6 +165,8 @@
             
             if (tabId === 'media') {
                 loadMediaData();
+            } else if (tabId === 'playlists') {
+                loadPlaylists();
             }
         }
 
@@ -194,6 +207,16 @@
                 renderMedia(data);
             } catch (err) {
                 logMessage(`Error loading media data: ${err}`);
+            }
+        }
+
+        async function loadPlaylists() {
+            try {
+                const pls = await window.electron.getPlaylists();
+                playlistsData = pls;
+                renderPlaylists();
+            } catch (err) {
+                logMessage(`Error loading playlists: ${err}`);
             }
         }
 
@@ -257,6 +280,33 @@
                     `;
                     linksList.appendChild(itemDiv);
                 }
+            });
+        }
+
+        function renderPlaylists() {
+            const container = document.getElementById('playlist-list');
+            container.innerHTML = '';
+            playlistsData.forEach(pl => {
+                const details = document.createElement('details');
+                const summary = document.createElement('summary');
+                summary.textContent = pl.name;
+                details.appendChild(summary);
+                const ul = document.createElement('ul');
+                (pl.items || []).forEach(id => {
+                    const item = allMediaData?.media.find(m => m._id === id.toString());
+                    if (item && !item.hashtags.includes('fullmedia')) {
+                        const li = document.createElement('li');
+                        li.textContent = item.title;
+                        ul.appendChild(li);
+                    }
+                });
+                const shuffleBtn = document.createElement('button');
+                shuffleBtn.textContent = 'Shuffle';
+                shuffleBtn.className = 'shuffle-playlist-btn';
+                shuffleBtn.dataset.plId = pl._id;
+                details.appendChild(shuffleBtn);
+                details.appendChild(ul);
+                container.appendChild(details);
             });
         }
 
@@ -389,6 +439,23 @@
             }
         });
 
+        document.getElementById('create-playlist-btn').addEventListener('click', async () => {
+            const input = document.getElementById('new-playlist-name');
+            const name = input.value.trim();
+            if (name) {
+                window.electron.createPlaylist(name);
+                input.value = '';
+            }
+        });
+
+        document.getElementById('playlists').addEventListener('click', async (e) => {
+            if (e.target.classList.contains('shuffle-playlist-btn')) {
+                const plId = e.target.dataset.plId;
+                await window.electron.shufflePlaylist(plId);
+                loadPlaylists();
+            }
+        });
+
         // Search functionality
         document.getElementById('search-box').addEventListener('input', (e) => {
             const query = e.target.value.trim().toLowerCase();
@@ -417,6 +484,10 @@
             renderMedia(data);
         });
 
+        window.electron.ipcRenderer.on('playlists-updated', () => {
+            loadPlaylists();
+        });
+
         // Listen for debug messages from main process
         window.electron.ipcRenderer.on('debug-log', (event, msg) => {
             logMessage(`[Main] ${msg}`);
@@ -426,6 +497,7 @@
         document.addEventListener('DOMContentLoaded', () => {
             logMessage('Application initialized');
             switchTab('media');
+            loadPlaylists();
         });
     </script>
 </body>

--- a/preload.js
+++ b/preload.js
@@ -1,6 +1,6 @@
-const { ipcRenderer, desktopCapturer } = require('electron');
+const { contextBridge, ipcRenderer, desktopCapturer } = require('electron');
 
-window.electron = {
+contextBridge.exposeInMainWorld('electron', {
   ipcRenderer,
   desktopCapturer,
   getStreamBase: () => ipcRenderer.invoke('get-stream-base'),
@@ -15,5 +15,11 @@ window.electron = {
   deleteLink: (url) => ipcRenderer.send('delete-link', url),
   deleteLocalFile: (filename) => ipcRenderer.send('delete-local-file', filename),
   addHashtag: (data) => ipcRenderer.send('add-hashtag', data),
-  searchMedia: (query) => ipcRenderer.invoke('search-media', query)
-}; 
+  searchMedia: (query) => ipcRenderer.invoke('search-media', query),
+  getPlaylists: () => ipcRenderer.invoke('get-playlists'),
+  createPlaylist: (name) => ipcRenderer.send('create-playlist', name),
+  addToPlaylist: (plId, itemId) => ipcRenderer.send('add-to-playlist', { plId, itemId }),
+  removeFromPlaylist: (plId, itemId) => ipcRenderer.send('remove-from-playlist', { plId, itemId }),
+  reorderPlaylist: (plId, order) => ipcRenderer.send('reorder-playlist', { plId, order }),
+  shufflePlaylist: (plId) => ipcRenderer.invoke('shuffle-playlist', plId)
+});


### PR DESCRIPTION
## Summary
- standardize database name in cleanup script and docs
- store playlists in MongoDB and add related IPC handlers
- expose new playlist APIs from preload via contextBridge
- enable `contextIsolation`
- implement Playlist tab UI and logic
- add trailing newlines to files

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6877cf163df4832a8b3d9af304fa6843